### PR TITLE
Add preview for SDK 2.0.0

### DIFF
--- a/app/src/main/java/io/dolby/app/features/publish/ui/PreviewVideoTrack.kt
+++ b/app/src/main/java/io/dolby/app/features/publish/ui/PreviewVideoTrack.kt
@@ -1,0 +1,40 @@
+package io.dolby.app.features.publish.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.viewinterop.AndroidView
+import com.millicast.Media
+import com.millicast.devices.track.VideoTrack
+import com.millicast.video.TextureViewRenderer
+import org.webrtc.RendererCommon
+
+@Composable
+fun PreviewVideoTrack(sourceTrack: VideoTrack, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val videoRenderer = remember(context) {
+        TextureViewRenderer(context).apply {
+            init(Media.eglBaseContext, null)
+            setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FIT)
+        }
+    }
+    Box(
+        modifier = modifier
+            .aspectRatio(16 / 9f),
+        contentAlignment = Alignment.Center
+    ) {
+        AndroidView(
+            modifier = Modifier.testTag("Preview"),
+            factory = { videoRenderer },
+            update = { view ->
+                view.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FIT)
+                sourceTrack.setVideoSink(videoRenderer)
+            }
+        )
+    }
+}

--- a/app/src/main/java/io/dolby/app/features/publish/ui/PublishScreen.kt
+++ b/app/src/main/java/io/dolby/app/features/publish/ui/PublishScreen.kt
@@ -3,6 +3,7 @@ package io.dolby.app.features.publish.ui
 import android.Manifest
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -31,6 +32,7 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
+import com.millicast.devices.track.VideoTrack
 import io.dolby.app.common.CollectSideEffect
 import io.dolby.app.common.ui.ButtonType
 import io.dolby.app.common.ui.DolbyButtonsContainer
@@ -148,6 +150,7 @@ fun PublishScreen(viewModel: PublishViewModel = koinInject()) {
                             )
                         }
                     }
+
                     PublishingType.VIDEO -> {
                         if (cameraPermissionState.status.shouldShowRationale) {
                             viewModel.onUiAction(
@@ -280,5 +283,40 @@ fun PublishScreen(viewModel: PublishViewModel = koinInject()) {
             buttonType = ButtonType.SECONDARY,
             isEnabled = uiState.isStopEnabled
         )
+
+        uiState.activeVideoTrack?.let {
+            if (uiState.shouldShowPreview) {
+                PreviewVideo(it)
+            }
+        }
+    }
+}
+
+@Composable
+fun PreviewVideo(videoTrack: VideoTrack) {
+    Spacer(modifier = Modifier.height(15.dp))
+    Text(
+        modifier = Modifier
+            .semantics {
+                contentDescription = "Stop Publishing"
+                testTag = "Stop Publishing"
+            }
+            .fillMaxWidth(),
+        text = "PREVIEW",
+        style = MaterialTheme.typography.body1,
+        color = MaterialTheme.colors.onSurface,
+        textAlign = TextAlign.Center
+    )
+    Spacer(modifier = Modifier.height(5.dp))
+    Box(
+        modifier = Modifier
+            .semantics {
+                contentDescription = "Playback Screen"
+                testTag = "Playback Screen"
+            }
+            .fillMaxWidth()
+            .background(MaterialTheme.colors.background)
+    ) {
+        PreviewVideoTrack(sourceTrack = videoTrack)
     }
 }

--- a/app/src/main/java/io/dolby/app/features/subscribe/ui/SubscribeScreen.kt
+++ b/app/src/main/java/io/dolby/app/features/subscribe/ui/SubscribeScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.semantics.testTag
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import io.dolby.app.features.subscribe.ui.tracks.Tracks
+import io.dolby.app.features.subscribe.ui.tracks.RemoteTracks
 import io.dolby.millicast.androidsdk.sampleapps.R
 import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
@@ -74,7 +74,7 @@ fun SubscribeScreen(
             .background(MaterialTheme.colors.background)
     ) {
         if (uiState.shouldShowTracks) {
-            Tracks(subscribeViewModel, Modifier.fillMaxSize())
+            RemoteTracks(subscribeViewModel, Modifier.fillMaxSize())
         }
     }
 }

--- a/app/src/main/java/io/dolby/app/features/subscribe/ui/tracks/RemoteTracks.kt
+++ b/app/src/main/java/io/dolby/app/features/subscribe/ui/tracks/RemoteTracks.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.dolby.app.features.subscribe.ui.SubscribeViewModel
 
 @Composable
-fun Tracks(subscribeViewModel: SubscribeViewModel, modifier: Modifier = Modifier) {
+fun RemoteTracks(subscribeViewModel: SubscribeViewModel, modifier: Modifier = Modifier) {
     val uiState by subscribeViewModel.uiState.collectAsStateWithLifecycle()
     LazyColumn(
         modifier = modifier,
@@ -18,7 +18,7 @@ fun Tracks(subscribeViewModel: SubscribeViewModel, modifier: Modifier = Modifier
         verticalArrangement = if (uiState.isMultiView) Arrangement.Top else Arrangement.Center
     ) {
         items(uiState.sourceVideoTracks.size) {
-            VideoTrack(uiState.sourceVideoTracks[it])
+            RemoteVideoTrack(uiState.sourceVideoTracks[it])
         }
     }
     uiState.audioTrack?.let {

--- a/app/src/main/java/io/dolby/app/features/subscribe/ui/tracks/RemoteVideoTrack.kt
+++ b/app/src/main/java/io/dolby/app/features/subscribe/ui/tracks/RemoteVideoTrack.kt
@@ -26,7 +26,7 @@ import io.dolby.app.common.ui.fontColor
 import org.webrtc.RendererCommon
 
 @Composable
-fun VideoTrack(
+fun RemoteVideoTrack(
     sourceTrack: RemoteVideoTrack,
     modifier: Modifier = Modifier
 ) {


### PR DESCRIPTION
Renamed the existing video track composables with the word remote. Copied the simpler previous version of video track composable as a preview video track specific composable.

Also centered the view and placed the word Preview outside of the video box.

https://jira.dolby.net/jira/browse/DIOS-6701 